### PR TITLE
Make example sketch filename match folder name

### DIFF
--- a/examples/TestTimer5/TestTimer5.ino
+++ b/examples/TestTimer5/TestTimer5.ino
@@ -1,5 +1,5 @@
 /**
- * 2016 Vincent Limorté
+ * 2016 Vincent LimortÃ©
  * Test and sample using Timer5 lib.
  *
  */


### PR DESCRIPTION
The Arduino IDE requires the sketch folder name to match the filename of the primary sketch file. This change causes the example sketch to be accessible via the Arduino IDE's **File > Examples > LIBRARYNAME** menu after the library is installed.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-examples